### PR TITLE
Fix minor typo on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ expect(store.commit).toHaveBeenCalledWith('setValue')
 expect(store.dispatch).toHaveBeenCalledWith('postValue')
 ```
 
-_Refer to the module example below using `getters` for a more detailed example, even though it is using only `getters`, it's exactly the same for `actions` and `mutations_`
+_Refer to the module example below using `getters` for a more detailed example, even though it is using only `getters`, it's exactly the same for `actions` and `mutations`_
 
 ### Mutating `state`, providing custom `getters`
 


### PR DESCRIPTION
Just a minor fix on readme, there was a small typo.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: minor typo fix

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number): it does not
- [x] All tests are passing: certainly
- [x] New/updated tests are included: no need

If adding a **new feature**, the PR's description includes: It does not!
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
